### PR TITLE
Add favicon support to rewriter

### DIFF
--- a/functions/index-template.html
+++ b/functions/index-template.html
@@ -9,6 +9,7 @@
 
   <!-- Meta Tags -->
   <meta name="description" content="@@DESCRIPTION@@">
+  <link rel="shortrcut icon" href="@@FAVICON@@">
 
   <meta property="og:title" content="@@TITLE@@" />
   <meta name="description" property="og:description" content="@@DESCRIPTION@@" />

--- a/functions/index-template.html
+++ b/functions/index-template.html
@@ -9,7 +9,7 @@
 
   <!-- Meta Tags -->
   <meta name="description" content="@@DESCRIPTION@@">
-  <link rel="shortrcut icon" href="@@FAVICON@@">
+  <link rel="shortcut icon" href="@@FAVICON@@">
 
   <meta property="og:title" content="@@TITLE@@" />
   <meta name="description" property="og:description" content="@@DESCRIPTION@@" />

--- a/functions/index.js
+++ b/functions/index.js
@@ -58,8 +58,8 @@ const getFabricApi = async (network) => {
   return resp.data["network"]["seed_nodes"]["fabric_api"][0];
 };
 
-const MaxCacheAge = 1000 * 60 * 5;  // 5min in millis
-let elvLiveDataCaches = {};
+const MaxCacheAge = 1000 * 60 * 5; // 5 min in millis
+let elvLiveDataCache = {};
 
 //
 // Firebase cloud functions definitions for rewrite support
@@ -143,10 +143,10 @@ exports.create_index_html = functions.https.onRequest(async (req, res) => {
 // load elv-live data from network or cache
 const loadElvLiveAsync = async (req) => {
   const [networkPrefix, networkId] = await getNetworkPrefix(req);
-  functions.logger.info("cache keys", Object.keys(elvLiveDataCaches));
-  let elvLiveDataCache = elvLiveDataCaches[networkId];
+  functions.logger.info("cache keys", Object.keys(elvLiveDataCache));
+  let elvLiveData = elvLiveDataCache[networkId];
 
-  const cache_date = elvLiveDataCache?.date;
+  const cache_date = elvLiveData?.date;
   if(!cache_date) {
     functions.logger.info("cache is empty");
   } else {
@@ -155,8 +155,8 @@ const loadElvLiveAsync = async (req) => {
     if(age_millis > MaxCacheAge) {
       functions.logger.info("cache is old, re-fetch");
     } else {
-      if(elvLiveDataCache.data)
-        return elvLiveDataCache.data;
+      if(elvLiveData.data)
+        return elvLiveData.data;
     }
   }
 
@@ -250,11 +250,10 @@ const loadElvLiveAsync = async (req) => {
     }
   });
 
-  elvLiveDataCache = { data: ret };
-  elvLiveDataCache["date"] = new Date().getTime();
-  functions.logger.info("elvLiveDataCache date", elvLiveDataCache["date"]);
-  //functions.logger.info("elv-live site metadata cache entry", elvLiveDataCache);
+  elvLiveData = { data: ret };
+  elvLiveData["date"] = new Date().getTime();
+  functions.logger.info("elvLiveData date", elvLiveData["date"]);
 
-  elvLiveDataCaches[networkId] = elvLiveDataCache;
+  elvLiveDataCache[networkId] = elvLiveData;
   return ret;
 };

--- a/functions/index.js
+++ b/functions/index.js
@@ -112,7 +112,7 @@ exports.create_index_html = functions.https.onRequest(async (req, res) => {
 
   let title = "Eluvio: The Content Blockchain";
   let description = "Web3 native content storage, streaming, distribution, and tokenization";
-  let image = "https://live.eluv.io/875458425032ed6b77076d67678a20a1.png";
+  let image = "https://live.eluv.io/7e927f3fc81c2e11f1ac317087288944.png";
   let favicon = "/favicon.png";
 
   // Inject metadata

--- a/functions/index.js
+++ b/functions/index.js
@@ -110,8 +110,8 @@ exports.create_index_html = functions.https.onRequest(async (req, res) => {
   const originalUrl = req.headers["x-forwarded-url"] || req.url;
   const fullPath = originalHost + originalUrl;
 
-  let title = "Eluvio Media Wallet";
-  let description = "Eluvio Media wallet accessed from " + fullPath;
+  let title = "Eluvio: The Content Blockchain";
+  let description = "Web3 native content storage, streaming, distribution, and tokenization";
   let image = "https://live.eluv.io/875458425032ed6b77076d67678a20a1.png";
   let favicon = "/favicon.png";
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -28,13 +28,18 @@ const FabricConfiguration = {
 const getNetworkAndMode = (req) => {
   const originalHost = req.headers["x-forwarded-host"] || req.hostname;
   const network = originalHost.indexOf("demov3") > -1 ? "demov3" : "main";
-  const mode = originalHost.indexOf("stg") > -1 ? "staging" : "production";
+  const mode = originalHost.indexOf("stg") > -1 || network == "demov3" ? "staging" : "production";
+
+  // allow testing instance to hit either config
+  if(originalHost == "elv-rewriter.web.app") { return ["main", "staging"]; }
+  if(originalHost == "elv-rewriter.firebaseapp.com") {return ["demov3", "staging"]; }
 
   return [network, mode];
 };
 
 const getNetworkPrefix = async (req) => {
   const [network, mode] = getNetworkAndMode(req);
+  functions.logger.info("network/mode:", network, mode);
   const prefix = await getFabricApi(network);
 
   return prefix + "/s/" + network +
@@ -106,17 +111,19 @@ exports.create_index_html = functions.https.onRequest(async (req, res) => {
   let title = "Eluvio Media Wallet";
   let description = "Eluvio Media wallet accessed from " + fullPath;
   let image = "https://live.eluv.io/875458425032ed6b77076d67678a20a1.png";
+  let favicon = "/favicon.png";
 
   // Inject metadata
   functions.logger.info("compare against incoming host", originalHost, "and url", originalUrl);
+  functions.logger.info("checking sites", Object.keys(sites));
   for(const [site, site_metadata] of Object.entries(sites)) {
-    functions.logger.info("checking", site);
     // match dns hostname, or match a path
     if(originalHost == site || originalUrl == ("/" + site)) {
       functions.logger.info("match", site, site_metadata);
       title = site_metadata.title;
       description = site_metadata.description;
       image = site_metadata.image;
+      favicon = site_metadata.favicon;
       break;
     }
   }
@@ -124,6 +131,7 @@ exports.create_index_html = functions.https.onRequest(async (req, res) => {
   html = html.replace(/@@TITLE@@/g, title);
   html = html.replace(/@@DESCRIPTION@@/g, description);
   html = html.replace(/@@IMAGE@@/g, image);
+  html = html.replace(/@@FAVICON@@/g, favicon);
   html = html.replace(/@@REWRITTEN_FROM@@/g, fullPath);
 
   res.status(200).send(html);
@@ -177,11 +185,16 @@ const loadElvLiveAsync = async (req) => {
     const description = event_info["description"] || "";
     const image = tenantsUrl + "/" + tenant_name + "/sites/" + site_name +
       "/info/event_images/hero_background?width=1200";
+    let favicon = "/favicon.png";
+    if("favicon" in site) {
+      favicon = tenantsUrl + "/" + tenant_name + "/sites/" + site_name + "/info/favicon";
+    }
 
     ret[tenant_name + "/" + site_name] = {
       "title": title,
       "description": description,
       "image": image,
+      "favicon": favicon,
     };
   }
 
@@ -202,11 +215,16 @@ const loadElvLiveAsync = async (req) => {
       const description = event_info["description"] || "";
       const image = featuredEventsUrl + "/" + idx + "/" + eventName +
         "/info/event_images/hero_background?width=1200";
+      let favicon = "/favicon.png";
+      if("favicon" in fe) {
+        favicon = featuredEventsUrl + "/" + idx + "/" + eventName + "/info/favicon";
+      }
 
       ret[eventName] = {
         "title": title,
         "description": description,
         "image": image,
+        "favicon": favicon,
       };
     }
   }

--- a/functions/index.js
+++ b/functions/index.js
@@ -30,7 +30,7 @@ const getNetworkAndMode = (req) => {
   const network = originalHost.indexOf("demov3") > -1 ? "demov3" : "main";
   const mode = originalHost.indexOf("stg") > -1 || network == "demov3" ? "staging" : "production";
 
-  // allow testing instance to hit either config
+  // allow testing instance to hit both configs
   if(originalHost == "elv-rewriter.web.app") { return ["main", "staging"]; }
   if(originalHost == "elv-rewriter.firebaseapp.com") {return ["demov3", "staging"]; }
 
@@ -42,9 +42,12 @@ const getNetworkPrefix = async (req) => {
   functions.logger.info("network/mode:", network, mode);
   const prefix = await getFabricApi(network);
 
-  return prefix + "/s/" + network +
-      "/qlibs/" + FabricConfiguration[network][mode].libId +
-      "/q/" + FabricConfiguration[network][mode].siteId;
+  return [
+    prefix + "/s/" + network +
+    "/qlibs/" + FabricConfiguration[network][mode].libId +
+    "/q/" + FabricConfiguration[network][mode].siteId,
+    network + ":" + mode
+  ];
 };
 
 const getFabricApi = async (network) => {
@@ -56,7 +59,7 @@ const getFabricApi = async (network) => {
 };
 
 const MaxCacheAge = 1000 * 60 * 5;  // 5min in millis
-let elv_live_data_cache = {};
+let elvLiveDataCaches = {};
 
 //
 // Firebase cloud functions definitions for rewrite support
@@ -90,7 +93,6 @@ exports.load_elv_live_data = functions.https.onRequest(async (req, res) => {
   try {
     let sites = await loadElvLiveAsync(req);
     functions.logger.info("loaded elv-live sites", {sites: sites});
-
     res.status(200).send(sites);
   } catch(error) {
     functions.logger.info(error);
@@ -140,7 +142,11 @@ exports.create_index_html = functions.https.onRequest(async (req, res) => {
 
 // load elv-live data from network or cache
 const loadElvLiveAsync = async (req) => {
-  const cache_date = elv_live_data_cache?.date;
+  const [networkPrefix, networkId] = await getNetworkPrefix(req);
+  functions.logger.info("cache keys", Object.keys(elvLiveDataCaches));
+  let elvLiveDataCache = elvLiveDataCaches[networkId];
+
+  const cache_date = elvLiveDataCache?.date;
   if(!cache_date) {
     functions.logger.info("cache is empty");
   } else {
@@ -149,12 +155,10 @@ const loadElvLiveAsync = async (req) => {
     if(age_millis > MaxCacheAge) {
       functions.logger.info("cache is old, re-fetch");
     } else {
-      if(elv_live_data_cache.data)
-        return elv_live_data_cache.data;
+      if(elvLiveDataCache.data)
+        return elvLiveDataCache.data;
     }
   }
-
-  const networkPrefix = await getNetworkPrefix(req);
 
   // load sites
   const tenantsUrl = networkPrefix + "/meta/public/asset_metadata/tenants";
@@ -246,9 +250,11 @@ const loadElvLiveAsync = async (req) => {
     }
   });
 
-  functions.logger.info("elv-live site metadata", ret);
-  elv_live_data_cache = { data: ret };
-  elv_live_data_cache["date"] = new Date().getTime();
-  functions.logger.info("elv_live_data_cache date", elv_live_data_cache["date"]);
+  elvLiveDataCache = { data: ret };
+  elvLiveDataCache["date"] = new Date().getTime();
+  functions.logger.info("elvLiveDataCache date", elvLiveDataCache["date"]);
+  //functions.logger.info("elv-live site metadata cache entry", elvLiveDataCache);
+
+  elvLiveDataCaches[networkId] = elvLiveDataCache;
   return ret;
 };


### PR DESCRIPTION
just `functions/` changes, for the rewriter
- add favicon support
- fix support for multi-network/mode data caching

----

base verification can use the elv-rewriter deployment:
- https://elv-rewriter.firebaseapp.com/bcl-live/masked-singer-drop-event --> demov3 --> has "test" favicon
```
curl -s https://elv-rewriter.firebaseapp.com/bcl-live/masked-singer-drop-event
  <link rel="shortrcut icon" href="https://host-76-74-28-235.contentfabric.io/s/demov3/qlibs/ilib36Wi5fJDLXix8ckL7ZfaAJwJXWGD/q/iq__2gkNh8CCZqFFnoRpEUmz7P3PaBQG/meta/public/asset_metadata/tenants/bcl-live/sites/masked-singer-drop-event/info/favicon">
```

- https://elv-rewriter.web.app/maskverse --> main --> default E. favicon
```
curl -s https://elv-rewriter.web.app/maskverse
  <link rel="shortrcut icon" href="/favicon.png">
```

and deployed to verify on demov3 staging:
```
curl -s https://live-stg.demov3.contentfabric.io/bcl-live/masked-singer-drop-event | grep "\(title\|link\)"
  <link rel="shortcut icon" href="https://host-76-74-91-17.contentfabric.io/s/demov3/qlibs/ilib36Wi5fJDLXix8ckL7ZfaAJwJXWGD/q/iq__2gkNh8CCZqFFnoRpEUmz7P3PaBQG/meta/public/asset_metadata/tenants/bcl-live/sites/masked-singer-drop-event/info/favicon">
```

``` 
curl -s https://live-stg.demov3.contentfabric.io/starflicks/starflicks | grep "\(title\|link\)"
  <link rel="shortcut icon" href="/favicon.png">
```
